### PR TITLE
unlvtests: Update path for tesseract executable

### DIFF
--- a/unlvtests/runalltests.sh
+++ b/unlvtests/runalltests.sh
@@ -2,7 +2,6 @@
 # File:        runalltests.sh
 # Description: Script to run a set of UNLV test sets for English.
 # Author:      Ray Smith
-# Created:     Thu Jun 14 08:21:01 PDT 2007
 #
 # (C) Copyright 2007, Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +24,7 @@ then
   echo "Run $0 from the tesseract-ocr root directory!"
   exit 1
 fi
-if [ ! -r src/api/tesseract ] && [ ! -r tesseract.exe ]
+if [ ! -r tesseract ] && [ ! -r tesseract.exe ]
 then
   echo "Please build tesseract before running $0"
   exit 1

--- a/unlvtests/runalltests_spa.sh
+++ b/unlvtests/runalltests_spa.sh
@@ -2,9 +2,8 @@
 ##############################################################################
 # File:        runalltests_spa.sh
 # Description: Script to run a set of UNLV test sets for Spanish.
-#                      based on runalltests.sh by Ray Smith
+#              based on runalltests.sh by Ray Smith
 # Author:      Shree Devi Kumar
-# Created:     June 09, 2018
 #
 # (C) Copyright 2007, Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +26,7 @@ then
   echo "Run $0 from the tesseract-ocr root directory!"
   exit 1
 fi
-if [ ! -r src/api/tesseract ] && [ ! -r tesseract.exe ]
+if [ ! -r tesseract ] && [ ! -r tesseract.exe ]
 then
   echo "Please build tesseract before running $0"
   exit 1

--- a/unlvtests/runtestset.sh
+++ b/unlvtests/runtestset.sh
@@ -2,7 +2,6 @@
 # File:        runtestset.sh
 # Description: Script to run tesseract on a single UNLV set.
 # Author:      Ray Smith
-# Created:     Wed Jun 13 10:13:01 PDT 2007
 #
 # (C) Copyright 2007, Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +24,7 @@ then
   echo "Run $0 from the tesseract-ocr root directory!"
   exit 1
 fi
-if [ ! -r src/api/tesseract ]
+if [ ! -r tesseract ]
 then
   if [ ! -r tesseract.exe ]
   then
@@ -35,7 +34,7 @@ then
     tess="./tesseract.exe"
   fi
 else
-  tess="time -f %U -o times.txt src/api/tesseract"
+  tess="time -f %U -o times.txt ./tesseract"
   #tess="time -f %U -o times.txt tesseract"
 fi
 


### PR DESCRIPTION
It was moved from src/api/tesseract to ./tesseract some time ago.